### PR TITLE
Ugrade Carbon version to 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add Aliases
 'PerfectMoney' => charlesassets\LaravelPerfectMoney\PerfectMoney::class,
 ```
 
-##Configuration
+### Configuration
 
 Publish Configuration file
 ```
@@ -49,7 +49,7 @@ PM_STATUS_URL=null
 PM_SUGGESTED_MEMO=null
 ```
 
-##Customizing views (Optional)
+### Customizing views (Optional)
 
 If you want to customize form, follow these steps.
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-		"nesbot/carbon": "2.*",
+        "nesbot/carbon": "2.*",
         "php" : "^7.1.8 || ^8.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "charlesassets/laravel-perfectmoney", 
+    "name": "charlesassets/laravel-perfectmoney",
     "type": "library",
     "description": "Laravel Package for Perfect Money Payments",
     "keywords": [
@@ -19,8 +19,8 @@
         }
     ],
     "require": {
-		"nesbot/carbon": "~1.20",
-        "php" : ">=5.3"
+		"nesbot/carbon": "2.*",
+        "php" : "^7.1.8 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "~4.0||~5.0",


### PR DESCRIPTION
To solve this issue when require LaravelPerfectMoney package for Laravel 7.x

```
╰─$ composer require charlesassets/laravel-perfectmoney
Using version ^1.0 for charlesassets/laravel-perfectmoney
./composer.json has been updated
Running composer update charlesassets/laravel-perfectmoney
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - charlesassets/laravel-perfectmoney[dev-master, 1.0.5] require nesbot/carbon ~1.20 -> found nesbot/carbon[1.20.0, ..., 1.39.1] but the package is fixed to 2.38.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
    - charlesassets/laravel-perfectmoney 1.0.x-dev is an alias of charlesassets/laravel-perfectmoney dev-master and thus requires it to be installed too.
    - Root composer.json requires charlesassets/laravel-perfectmoney ^1.0 -> satisfiable by charlesassets/laravel-perfectmoney[1.0.5, 1.0.x-dev (alias of dev-master)].

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
```